### PR TITLE
Fixed Sound Error in main

### DIFF
--- a/my_game.py
+++ b/my_game.py
@@ -734,7 +734,7 @@ class InGameView(arcade.View):
 
         # check if the player is dead
         if self.player_sprite.lives <= 0:
-            arcade.stop_sound(self.sound_thrust_player)
+            self.sound_thrust.stop(self.sound_thrust_player)
             arcade.unschedule(self.spawn_ufo)
             game_over_view = GameOverView(player_score=self.player_score, level=self.level)
             self.window.show_view(game_over_view)


### PR DESCRIPTION
The problem was that the .stop_sound() command takes the player of the sound, which in this case had been .killed, as an argument, and therefore it couldn't run. By using the .stop() command, which doesn't need a player instead this is no problem at all.